### PR TITLE
Fixes failing Firefox tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ after_failure:
 
 notifications:
   email:
-  - damon.oehlman@nicta.com.au
+  - nathan.oehlman@nicta.com.au

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: node_js
 node_js:
 - 0.10
+- 4.1
+- stable
 
 env:
   matrix:


### PR DESCRIPTION
The scheme tests were failing due to no media streams being present - which in newer versions of Firefox causes the second peer to generate no ICE candidates, and fail immediately after the answer is set as the local description.

Adds testing for more versions of Node also.